### PR TITLE
[Feat] API 요청 세팅 & 공통 패치 함수 정의

### DIFF
--- a/src/service/api/handleApiReqeust.ts
+++ b/src/service/api/handleApiReqeust.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+import type Response from '@/types/Responsne';
+
+/**
+ * 모든 Reqeust 요청을 보낼 때 사용하는 함수,
+ * Reqeust Error시 string 타입 에러 메세지만 반환함
+ *
+ * 해당 함수 호출부에서 try/catch 블럭으로 에러핸들링
+ *
+ * Response 데이터 타입을 제네릭 형태로 넣어줘야함
+ *
+ * ex) handleApiReqeust<DataType>(() =>client.get(endPoint))
+ * @param function
+ * @returns ResponseData
+ */
+
+const handleApiReqeust = async <T>(fetchApi: () => Promise<Response<T>>): Promise<T> => {
+  try {
+    const response = await fetchApi();
+
+    if (response.resultCode === 'SUCCESS') {
+      return response.result;
+    }
+
+    // resultCode != SUCCESS 일 시 모든 요청 throw
+    throw response.result;
+  } catch (error) {
+    if (axios.isAxiosError<Response<T>>(error)) {
+      if (error.status === 500) {
+        // 500 -> 서버에러
+        throw '서버에서 오류가 발생했습니다.';
+      }
+
+      if (error.response && error.response.data.resultCode === 'ERROR') {
+        // 요청 에러
+        throw error.response.data.result || '요청을 정상적으로 처리하지 못했습니다.';
+      }
+    }
+
+    // 기타 에러
+    throw '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+  }
+};
+
+export default handleApiReqeust;

--- a/src/service/instance/client.ts
+++ b/src/service/instance/client.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const client = axios.create({
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default client;

--- a/src/types/Responsne.d.ts
+++ b/src/types/Responsne.d.ts
@@ -1,0 +1,11 @@
+export type Response<T> =
+  | {
+      resultCode: 'SUCCESS';
+      result: T;
+    }
+  | {
+      resultCode: 'ERROR';
+      result: string;
+    };
+
+export default Response;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,26 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv, type ConfigEnv } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
+export default defineConfig(({ mode }: ConfigEnv) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
     },
-  },
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
- Vite Proxy 설정 (e7b0aaf8cc658e0ef57d874948af73efb3a7e1f8)
> 백엔드 서버 https 설정되면, 추후 proxy 설정도 https로 바꿀 예정입니다

- axios 공통 instance 정의 (26556b46b7fc02b45d456a131abb03a8ac927a6b)
> 패치 할 때 사용할 공통 instance 정의했습니다. baseURL 은 proxy 사용하고 있어서 따로 정의 해두지 않았어요, header 쪽 인증 로직은 변수로 넣어서 추가하겠습니다

- API 공통 Response 타입 인터페이스 정의 (4131ea21b88836d76399ab36b85400084ef1cab7)
> API 공통 Response 타입을 인터페이스로 정의했습니다 result 쪽 데이터는 제네릭 타입으로 지정해뒀어요

- API 요청 보낼 때 사용 할 공통 패치 함수 정의 (343422ad047164dfbb9d0748952e6ff767a5bfd9)
> 함수 내용은 주석 참고하시면 될 것 같고, 에러 핸들링 할 때 보일러 플레이트 코드가 너무 많이 생길 것 같아서 에러 핸들링 로직을 중앙화 해놓은 함수입니다 응답에 성공하면 데이터를 반환하고, 에러가 나면 **에러 객체 대신 string 타입 에러 메세지만 throw** 하도록 해놨습니다 